### PR TITLE
[DL-5685] Use the belgian timezone for all date formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## Unreleased
+- format all dates using the same timezone [DL-5685]
+### deploy instructions
+```
+drc restart complaint-form-email-converter
+```
 ## 2.0.2 (2024-01-30)
 - correct dispatcher rules [DL-5603]
 ## 2.0.1 (2024-01-30)

--- a/config/complaint-form-email-converter/templates/receiverEmail.js
+++ b/config/complaint-form-email-converter/templates/receiverEmail.js
@@ -1,7 +1,6 @@
-import { format } from 'date-fns';
-import { formatInTimeZone } from 'date-fns-tz';
 import envvar from 'env-var';
 import * as uti from './utils';
+import { formatDate } from './utils';
 
 const fileDownloadPrefix = envvar
   .get('FILE_DOWNLOAD_PREFIX')
@@ -38,12 +37,8 @@ function attachmentsHtml(attachments) {
 
 export function receiverEmailPlainTextContent(form, attachments) {
   const verzondenFrom = uti.senderName(form);
-  const verzondenAt = formatInTimeZone(
-    form.created,
-    'Europe/Brussels',
-    'dd/MM/yyyy HH:mm',
-  );
-  const ontvangenAt = format(new Date(), 'dd/MM/yyyy HH:mm');
+  const verzondenAt = formatDate(form.created);
+  const ontvangenAt = formatDate(new Date());
   return `Geachte
 Er werd een klacht ingediend bij het Agentschap Binnenlands Bestuur via het Digitaal Klachtenformulier. Hieronder vindt u de inhoud van de klacht en de gegevens van klager
 
@@ -73,12 +68,8 @@ ABB Vlaanderen`;
 
 export function receiverEmailHtmlContent(form, attachments) {
   const verzondenFrom = uti.senderName(form);
-  const verzondenAt = formatInTimeZone(
-    form.created,
-    'Europe/Brussels',
-    'dd/MM/yyyy HH:mm',
-  );
-  const ontvangenAt = format(new Date(), 'dd/MM/yyyy HH:mm');
+  const verzondenAt = formatDate(form.created);
+  const ontvangenAt = formatDate(new Date());
   return `<p>Geachte</p>
 <br>
 <p>Er werd een klacht ingediend bij het Agentschap Binnenlands Bestuur via het Digitaal Klachtenformulier. Hieronder vindt u de inhoud van de klacht en de gegevens van klager</p>

--- a/config/complaint-form-email-converter/templates/senderEmail.js
+++ b/config/complaint-form-email-converter/templates/senderEmail.js
@@ -1,6 +1,5 @@
-import { format } from 'date-fns';
-import { formatInTimeZone } from 'date-fns-tz';
 import * as uti from './utils';
+import { formatDate } from './utils';
 
 export function senderEmailSubject() {
   return 'Uw klacht over de werking van een lokaal bestuur.';
@@ -20,12 +19,9 @@ function attachmentsHtml(attachments) {
 
 export function senderEmailPlainTextContent(form, attachments) {
   const verzondenFrom = uti.senderName(form);
-  const verzondenAt = formatInTimeZone(
-    form.created,
-    'Europe/Brussels',
-    'dd/MM/yyyy HH:mm',
-  );
-  const ontvangenAt = format(new Date(), 'dd/MM/yyyy HH:mm');
+  const verzondenAt = formatDate(form.created);
+  const ontvangenAt = formatDate(new Date());
+
   return `Geachte ${verzondenFrom}
 Het Agentschap Binnenlands Bestuur Vlaanderen heeft uw klacht goed ontvangen:
 
@@ -57,12 +53,8 @@ ABB Vlaanderen`;
 
 export function senderEmailHtmlContent(form, attachments) {
   const verzondenFrom = uti.senderName(form);
-  const verzondenAt = formatInTimeZone(
-    form.created,
-    'Europe/Brussels',
-    'dd/MM/yyyy HH:mm',
-  );
-  const ontvangenAt = format(new Date(), 'dd/MM/yyyy HH:mm');
+  const verzondenAt = formatDate(form.created);
+  const ontvangenAt = formatDate(new Date());
   return `<p>Geachte ${verzondenFrom}</p>
 <br>
 <p>Het Agentschap Binnenlands Bestuur Vlaanderen heeft uw klacht goed ontvangen:</p>

--- a/config/complaint-form-email-converter/templates/utils.js
+++ b/config/complaint-form-email-converter/templates/utils.js
@@ -1,3 +1,5 @@
+import { formatInTimeZone } from 'date-fns-tz';
+
 export function senderName(form) {
   let senderName = form.name;
   if (form.contactPersonName != '-') {
@@ -12,4 +14,13 @@ export function humanReadableSize(size) {
   if (bytes == 0) return '0 byte';
   const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
   return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
+}
+
+/** @arg {Date} date */
+export function formatDate(date) {
+  return formatInTimeZone(
+    date,
+    'Europe/Brussels',
+    'dd/MM/yyyy HH:mm'
+  );
 }


### PR DESCRIPTION
We output this date in the emails, so it needs to be consistent with the sent date to not cause confusion.

To test:
- run the stack
- use the bundled frontend to submit the complaint form (this only works in localhost / https environments due to window.crypto usage in the frontend code, if you run into issues run the frontend locally and proxy to the local backend)
- check the complaint-form-email-converter service logs, and verify that the dates in the generated emails are correct