### PR TITLE
Increase grace period on delta-notifier

### DIFF
--- a/config/delta-notifier/complaintConverter.js
+++ b/config/delta-notifier/complaintConverter.js
@@ -17,7 +17,7 @@ export default [
     },
     options: {
       resourceFormat: 'v0.0.1',
-      gracePeriod: 250,
+      gracePeriod: 60000,
       ignoreFromSelf: true,
     },
   },


### PR DESCRIPTION
**[DL-7013]**

On complaints with a lot of attachments, it takes a while for `mu-cl-resource` to write them to the triplestore. The complaint itself is written earlier and delta messages about the complaint already reach the converter service before the triples about the attachments are written. This causes the converter service to not see the attachments (yet) and it continues to write mails without attachments.

We can safely increase the grace period on the `delta-notifier` to a longer wait time. It can be dodgy to have long `gracePeriod`s because of instability, but the converter service periodically runs a CRON job that does the same as what a delta message causes.