### PR TITLE
DL-7278: updated privacy url in senderEmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Unreleased
+- [DL-7278] adjust privacy link
+
+### Deploy instructions
+```
+drc restart complaint-form-email-converter
+```
+
 ## 2.3.1 (2026-01-30)
 - [DL-7038] Klachtenformulier follow-up: improve conversion to email
 - [DL-6579] sparql-parser added

--- a/config/complaint-form-email-converter/templates/senderEmail.js
+++ b/config/complaint-form-email-converter/templates/senderEmail.js
@@ -45,7 +45,7 @@ Bijlagen
 ${attachmentsPlainText(attachments)}
 
 Het Agentschap Binnenlands Bestuur zal u zo snel als mogelijk verdere informatie sturen over het gevolg dat aan uw klacht wordt gegeven. Meer info hierover vindt u in de rubriek “Wat doet de toezichthoudende overheid met je klacht?” in de klachtenwegwijzer (https://lokaalbestuur.vlaanderen.be/klachtenwegwijzer).
-Info over de verwerking van uw gegevens leest u hier: binnenland.vlaanderen.be/privacyverklaring-abb.
+Info over de verwerking van uw gegevens leest u hier: https://www.vlaanderen.be/agentschap-binnenlands-bestuur/privacyverklaring.
 
 Hoogachtend
 ABB Vlaanderen`;
@@ -123,7 +123,7 @@ export function senderEmailHtmlContent(form, attachments) {
 <p>
   Het Agentschap Binnenlands Bestuur zal u zo snel als mogelijk verdere informatie sturen over het gevolg dat aan uw klacht wordt gegeven. Meer info hierover vindt u in de rubriek “Wat doet de toezichthoudende overheid met je klacht?” in de klachtenwegwijzer (<a href="https://lokaalbestuur.vlaanderen.be/klachtenwegwijzer" target="_blank">https://lokaalbestuur.vlaanderen.be/klachtenwegwijzer</a>).
   <br>
-  Info over de verwerking van uw gegevens leest u hier: <a href="https://binnenland.vlaanderen.be/privacyverklaring-abb" target="_blank">https://binnenland.vlaanderen.be/privacyverklaring-abb</a>.
+  Info over de verwerking van uw gegevens leest u hier: <a href="https://www.vlaanderen.be/agentschap-binnenlands-bestuur/privacyverklaring" target="_blank">https://www.vlaanderen.be/agentschap-binnenlands-bestuur/privacyverklaring</a>.
 </p>
 <br>
 <p>Hoogachtend</p>


### PR DESCRIPTION
- Updated privacy url

TO TEST:
- start stack
- create complaint via frontend
- check complaint-form-email-converter logs for change in URL

dc override:
`services:
  complaint-form-warning:
    environment:
      EMAIL_FROM: person1@mail.com
      EMAIL_TO: person2@mail.com

  error-alert:
    environment:
      EMAIL_FROM: person1@mail.com
      EMAIL_TO: person2@mail.com

  complaint-form-email-converter:
    environment:
      FILE_DOWNLOAD_PREFIX: 'http://localhost/'`